### PR TITLE
* Generalize env variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 ## Requirements
 
 The Vault client assumes that you have a reachable and set up Vault server. The following env vars are required:
-- `EDEX_VAULT_URL`: Vault host.
-- `EDEX_VAULT_USERNAME`: Vault user username provided by an admin/operator.
-- `EDEX_VAULT_PWD`: Vault user password provided by an admin/operator.
+- `VAULT_URL`: Vault host.
+- `VAULT_USERNAME`: Vault user username provided by an admin/operator.
+- `VAULT_PWD`: Vault user password provided by an admin/operator.
 - `NODE_ENV`: Specifies what type of environment it's running.
 
 ## How it works

--- a/cache.js
+++ b/cache.js
@@ -11,7 +11,7 @@ const path = require("path");
 // Const and vars
 //////
 
-const secFilename = process.env.EDEX_VAULT_CACHE_FILENAME || ".sec.json";
+const secFilename = process.env.VAULT_CACHE_FILENAME || ".sec.json";
 
 //////
 // Exported functionality(ies)

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = (settings) => {
 	// Merges the default and user settings
 	settings = Object.assign({
 		// Secret version
-		secretVersion: process.env.EDEX_VAULT_SECRETS_VERSION, // default to latest
+		secretVersion: process.env.VAULT_SECRETS_VERSION, // default to latest
 		// Human auth strategy
 		humanAuthStrategy: "userpass",
 		// Machine to machine auth strategy

--- a/integration-test.js
+++ b/integration-test.js
@@ -40,7 +40,7 @@ require("./index")({
 assertions();
 
 // Loading from cache scenario
-process.env.EDEX_VAULT_URL = "blablabla";
+process.env.VAULT_URL = "blablabla";
 require("./index")();
 assertions();
 

--- a/request.js
+++ b/request.js
@@ -10,7 +10,7 @@ const request = require("sync-request");
 // Const and vars
 //////
 
-const host = process.env.EDEX_VAULT_URL;
+const host = process.env.VAULT_URL;
 
 //////
 // Validates env vars

--- a/strategies/userpass.js
+++ b/strategies/userpass.js
@@ -10,8 +10,8 @@ const request = require("../request");
 // Const and vars
 //////
 
-const username = process.env.EDEX_VAULT_USERNAME;
-const pwd = process.env.EDEX_VAULT_PWD;
+const username = process.env.VAULT_USERNAME;
+const pwd = process.env.VAULT_PWD;
 
 //////
 // Validates env vars


### PR DESCRIPTION
Generalized variable names by removing all references to `EDEX` since this client will be used on other projects.